### PR TITLE
fix(manifest_indexing): NameError: name 'creds' is not defined

### DIFF
--- a/manifest_indexing/indexd_manifest_job.py
+++ b/manifest_indexing/indexd_manifest_job.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     # Only use provided authz requirement if resources are not empty
     access_authz_requirement = JOB_REQUIRES
-    if creds.get("job_requires", {}).get("job_access_req"):
+    if indexing_creds.get("job_requires", {}).get("job_access_req"):
         access_authz_requirement = creds.get("job_requires")
 
     # check if user has sower and ingestion policies


### PR DESCRIPTION
Fixing this issue:
```
jenkins-brain@cdistest_dev_admin:~/cdis-manifest$ kc logs manifest-indexing-otmyk-gb7px
Traceback (most recent call last):
  File "manifest_indexing_job.py", line 42, in <module>
    if creds.get("job_requires", {}).get("job_access_req"):
NameError: name 'creds' is not defined
```