### PR TITLE
chore(python_quay_builds): migrate from python:3.6 image to quay pyth…

### DIFF
--- a/manifest_indexing/indexd_manifest_job.Dockerfile
+++ b/manifest_indexing/indexd_manifest_job.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM quay.io/cdis/python:3.6
 
 RUN pip install gen3==2.4.0
 RUN pip install boto3==1.11.11

--- a/manifest_indexing/manifest_indexing.Dockerfile
+++ b/manifest_indexing/manifest_indexing.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM quay.io/cdis/python:3.6
 
 RUN pip install gen3==2.4.0
 RUN pip install boto3==1.11.11

--- a/manifest_merging/manifest_merging.Dockerfile
+++ b/manifest_merging/manifest_merging.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM quay.io/cdis/python:3.6
 
 RUN pip install gen3==2.5.0
 RUN pip install boto3==1.11.11

--- a/metadata_ingestion/get_dbgap_metadata_manifest.Dockerfile
+++ b/metadata_ingestion/get_dbgap_metadata_manifest.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM quay.io/cdis/python:3.6
 
 RUN pip install gen3==2.4.0
 RUN pip install boto3==1.11.11

--- a/metadata_ingestion/metadata_ingestion.Dockerfile
+++ b/metadata_ingestion/metadata_ingestion.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM quay.io/cdis/python:3.6
 
 RUN pip install gen3==2.4.0
 RUN pip install boto3==1.11.11


### PR DESCRIPTION
### Bug Fixes
- Build python image from quay, avoiding Dockerhub rate limit 
