### PR TITLE
Export Job to IRSA

### DIFF
--- a/export_job/export_zip_from_manifest_job.py
+++ b/export_job/export_zip_from_manifest_job.py
@@ -97,6 +97,8 @@ def upload_export_to_s3(bucket_name, username):
     """
     Uploads the local zip export to S3 and returns a presigned URL, expires after 1 hour.
     """
+    print("Printing Bucket Name 2 in upload export to s3")
+    print(bucket_name)
 
     s3_client = boto3.client("s3")
 
@@ -124,6 +126,8 @@ if __name__ == "__main__":
     access_token = os.environ["ACCESS_TOKEN"]
     hostname = os.environ["GEN3_HOSTNAME"]
     bucket_name = os.environ["BUCKET"]
+    print("Printing Bucket Name 1")
+    print(bucket_name)
 
     try:
         input_data = json.loads(os.environ["INPUT_DATA"])

--- a/export_job/export_zip_from_manifest_job.py
+++ b/export_job/export_zip_from_manifest_job.py
@@ -97,8 +97,6 @@ def upload_export_to_s3(bucket_name, username):
     """
     Uploads the local zip export to S3 and returns a presigned URL, expires after 1 hour.
     """
-    print("Printing Bucket Name 2 in upload export to s3")
-    print(bucket_name)
 
     s3_client = boto3.client("s3")
 
@@ -126,7 +124,7 @@ if __name__ == "__main__":
     access_token = os.environ["ACCESS_TOKEN"]
     hostname = os.environ["GEN3_HOSTNAME"]
     bucket_name = os.environ["BUCKET"]
-    print("Printing Bucket Name 1")
+    print("Printing Bucket Name")
     print(bucket_name)
 
     try:

--- a/export_job/export_zip_from_manifest_job.py
+++ b/export_job/export_zip_from_manifest_job.py
@@ -123,6 +123,7 @@ def fail(error_message=DEFAULT_ERROR_MESSAGE):
 if __name__ == "__main__":
     access_token = os.environ["ACCESS_TOKEN"]
     hostname = os.environ["GEN3_HOSTNAME"]
+    bucket_name = os.environ["BUCKET"]
 
     try:
         input_data = json.loads(os.environ["INPUT_DATA"])
@@ -137,7 +138,6 @@ if __name__ == "__main__":
         fail(
             "No studies or files provided. Please select some studies or files and try again."
         )
-        bucket_name = os.getenv("bucket_name")
 
     try:
         username_req = requests.get(

--- a/export_job/export_zip_from_manifest_job.py
+++ b/export_job/export_zip_from_manifest_job.py
@@ -123,10 +123,11 @@ def fail(error_message=DEFAULT_ERROR_MESSAGE):
 if __name__ == "__main__":
     access_token = os.environ["ACCESS_TOKEN"]
     hostname = os.environ["GEN3_HOSTNAME"]
-    bucket_name = os.environ["BUCKET"]
-    print("Printing Bucket Name")
-    print(bucket_name)
-
+    try:
+        bucket_name = os.environ["BUCKET"]
+    except Exception as e:
+        print(f"Error: Environment variable 'BUCKET' is not set.")
+        fail()
     try:
         input_data = json.loads(os.environ["INPUT_DATA"])
     except Exception as e:


### PR DESCRIPTION
changing the export job to use environment variables and IRSA instead of access keys

### Improvements
changing the batch export job to use IRSA instead of access keys. Also, changing the job to use environment variables to read in the bucket name for the batch export job. 

### Deployment changes
Manifest.json files MUST be changed to use the new "batch-export-sa" service account and the "BUCKET" environment variable must be set to the batch-export-g3auto secret with the "bucket_name" key. You also no longer need to mount the batch-export-g3auto secret as this is now deprecated (it is replaced by the batch-export-g3auto configmap). 
```
"serviceAccountName": "batch-export-sa"...


      - name: BUCKET
        valueFrom:
           configMapKeyRef:
            name: batch-export-g3auto
            key: bucket_name

Remove the following:   
       "volumeMounts": [
          {
            "name": "batch-export-creds-volume",
            "readOnly": true,
            "mountPath": "/batch-export-creds.json",
            "subPath": "config.json"
          }
        ],
      },
      "volumes": [
        {
          "name": "batch-export-creds-volume",
          "secret": {
            "secretName": "batch-export-g3auto"
          }
        }
      ],
